### PR TITLE
Add request and response types.

### DIFF
--- a/http_types/__init__.py
+++ b/http_types/__init__.py
@@ -107,3 +107,11 @@ class Response(_Response, total=True):
 
     """ Response status code."""
     status_code: int
+
+
+class RequestResponsePair(TypedDict, total=True):
+    """
+    HTTP request-response pair.
+    """
+    req: Request
+    res: Response

--- a/http_types/__init__.py
+++ b/http_types/__init__.py
@@ -1,5 +1,5 @@
 from typing_extensions import Literal, TypedDict
-from typing import Mapping, Any, Union
+from typing import Mapping, Any
 
 """
 HTTP request or response headers. Array-valued header values can be represented with a comma-separated string.

--- a/http_types/__init__.py
+++ b/http_types/__init__.py
@@ -1,10 +1,109 @@
 from typing_extensions import Literal, TypedDict
+from typing import Mapping, Any, Union
+
+"""
+HTTP request or response headers. Array-valued header values can be represented with a comma-separated string.
+"""
+Headers = Mapping[str, str]
+
+"""
+HTTP request query parameters.
+"""
+Query = Mapping[str, str]
+
+"""
+HTTP request protocol.
+"""
+Protocol = Literal['http', 'https']
 
 
-class Request(TypedDict, total=True):
-    method: Literal['get', 'put', 'post', 'patch',
-                    'delete', 'options', 'trace', 'head', 'connect']
+class _Request(TypedDict, total=False):
+    """
+    Optional fields for Request.
+    """
+
+    """
+    HTTP request body as JSON. Could be dictionary, list, or string.
+    """
+    body_as_json: Any
 
 
-class Response(TypedDict, total=True):
-    code: int
+class Request(_Request, total=True):
+    """
+    HTTP request.
+    """
+
+    """
+    Request method.
+    """
+    method: Literal['get',
+                    'put',
+                    'post',
+                    'patch',
+                    'delete',
+                    'options',
+                    'trace',
+                    'head',
+                    'connect']
+
+    """
+    Request headers.
+    """
+    headers: Headers
+
+    """
+    Query parameters.
+    """
+    query: Query
+
+    """
+    Request body. Empty string if empty.
+    """
+    body: str
+
+    """
+    Request host, possibly including port number.
+    """
+    host: str
+
+    """
+    Full request path.
+    Example value: '/v1/pets?id=234'
+    """
+    path: str
+
+    """
+    Request pathname, not containing query parameters etc.
+    Example value: '/v1/pets'
+    """
+    pathname: str
+
+    """
+    Request protocol.
+    """
+    protocol: Protocol
+
+
+class _Response(TypedDict, total=False):
+    """
+    Optional fields for Response.
+    """
+
+    """
+    Response body as JSON. Could be dictionary, list, or string.
+    """
+    body_as_json: Any
+
+
+class Response(_Response, total=True):
+    """
+    HTTP response.
+    """
+
+    """
+    Response body.
+    """
+    body: str
+
+    """ Response status code."""
+    status_code: int


### PR DESCRIPTION
Add types for HTTP request and response using [TypedDict](https://www.python.org/dev/peps/pep-0589/). Tried to keep feature parity with [unmock-js](https://github.com/unmock/unmock-js/blob/dev/packages/unmock-core/src/interfaces.ts#L647) types, with the exception that kept header and query parameter values as strings. I'm not sure there's any value typing them as numbers or arrays of strings as in `unmock-js`.

TODO in future:
- [ ]  Helper methods for parsing `Request` and `Response` from a dictionary, adding type guards with [typeguard](https://pypi.org/project/typeguard/) to ensure run-time type checking.