### PR TITLE
Add LICENSE file and pypi and license badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2019-2020 Meeshkan. https://meeshkan.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # HTTP types in Python
 
-[![CircleCI](https://circleci.com/gh/Meeshkan/py-http-types.svg?style=svg)](https://circleci.com/gh/Meeshkan/py-http-types)
+[![CircleCI](https://circleci.com/gh/Meeshkan/py-http-types.svg?style=shield)](https://circleci.com/gh/Meeshkan/py-http-types)
+[![PyPi](https://img.shields.io/pypi/pyversions/http-types)](https://pypi.org/project/http-types/)
+[![License](https://img.shields.io/pypi/l/http-types)](LICENSE)
 
 Types for HTTP request and response.
 


### PR DESCRIPTION
The change in Cirrus CI badge style is to align with the other badges better:

<img width="319" alt="badges" src="https://user-images.githubusercontent.com/277251/72908489-d38cc300-3d35-11ea-9312-a4a12172d91d.png">
