### PR TITLE
Use covariant types Sequence and Mapping.

### DIFF
--- a/http_types/types.py
+++ b/http_types/types.py
@@ -1,5 +1,5 @@
 from typing_extensions import Literal, TypedDict
-from typing import Any, Dict, Union, List, Mapping, Sequence
+from typing import Any, Union, Mapping, Sequence
 
 """
 HTTP request or response headers. Array-valued header values can be represented with a comma-separated string.

--- a/http_types/types.py
+++ b/http_types/types.py
@@ -1,15 +1,15 @@
 from typing_extensions import Literal, TypedDict
-from typing import Any, Dict, Union, List
+from typing import Any, Dict, Union, List, Mapping, Sequence
 
 """
 HTTP request or response headers. Array-valued header values can be represented with a comma-separated string.
 """
-Headers = Dict[str, Union[str, List[str]]]
+Headers = Mapping[str, Union[str, Sequence[str]]]
 
 """
 HTTP request query parameters.
 """
-Query = Dict[str, Union[str, List[str]]]
+Query = Mapping[str, Union[str, Sequence[str]]]
 
 """
 HTTP request protocol.


### PR DESCRIPTION
- Removes `Dict` and `List` that are invariant in their type parameters, replace with `Mapping` and `Sequence`
- The problem was that, for example, `parse_qs` returns `Dict[str, List[str]]` for the query parameters. This cannot be substituted to `Query=Dict[str, Union[str, List[str]]]`, because `Dict` is invariant and requires the type argument to be exactly the given (even if `Union` is covariant, i.e., one can substitute `str` to `Union[str, List[str]]`