### PR TITLE
Fix bug in inferring path from url without path.

### DIFF
--- a/http_types/utils.py
+++ b/http_types/utils.py
@@ -39,7 +39,7 @@ def parse_pathname(path: str) -> str:
     return urlparse(path).path
 
 
-path_capture = re.compile(r"https?:\/\/[a-zA-Z\.]+(?:(\/(?:\S)*)|$)")
+path_capture = re.compile(r"$https?:\/\/[a-zA-Z\.]+(?:(\/(?:\S)*)|$)")
 
 
 def path_from_url(url: str) -> str:
@@ -54,7 +54,7 @@ def path_from_url(url: str) -> str:
     """
     match_result = path_capture.match(url)
     if match_result is None:
-        raise Exception("Cannot parse URL {url}".format(url=url))
+        raise Exception("Unknown format for url {url}".format(url=url))
     groups = match_result.groups()
     if len(groups) == 0 or groups[0] == None:  # Path empty
         return "/"

--- a/http_types/utils.py
+++ b/http_types/utils.py
@@ -39,7 +39,7 @@ def parse_pathname(path: str) -> str:
     return urlparse(path).path
 
 
-path_capture = re.compile(r"$https?:\/\/[a-zA-Z\.]+(?:(\/(?:\S)*)|$)")
+path_capture = re.compile(r"^https?:\/\/[a-zA-Z\.]+(\/(?:\S)*)?$")
 
 
 def path_from_url(url: str) -> str:
@@ -56,7 +56,7 @@ def path_from_url(url: str) -> str:
     if match_result is None:
         raise Exception("Unknown format for url {url}".format(url=url))
     groups = match_result.groups()
-    if len(groups) == 0 or groups[0] == None:  # Path empty
+    if len(groups) == 0 or groups[0] is None:  # Path empty
         return "/"
     else:
         return groups[0]

--- a/http_types/utils.py
+++ b/http_types/utils.py
@@ -39,7 +39,7 @@ def parse_pathname(path: str) -> str:
     return urlparse(path).path
 
 
-path_capture = re.compile(r"^https?:\/\/[a-zA-Z\.]+(\/(?:\S)*)?$")
+path_capture = re.compile(r"^https?:\/\/[^\/]+(\/(?:\S)*)?$")
 
 
 def path_from_url(url: str) -> str:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -53,18 +53,34 @@ def test_from_url():
     assert req['query'] == {'id': "1", 'q': ["v1", "v2"]}
 
 
+def test_from_url_without_path():
+    test_url = "https://api.github.com"
+    req = RequestBuilder.from_url(test_url)
+    assert req['path'] == "/"
+    assert req['pathname'] == "/"
+
+
+def test_from_url_with_root_path():
+    test_url = "https://api.github.com/"
+    req = RequestBuilder.from_url(test_url)
+    assert req['path'] == "/"
+    assert req['pathname'] == "/"
+
+
 def test_from_json():
     with open(SAMPLE_JSON, "r", encoding="utf-8") as f:
         exchange = HttpExchangeReader.from_json(f.read())
-        assert exchange['request']['timestamp'] == datetime.fromisoformat("2018-11-13T20:20:39+02:00")
-        assert exchange['response']['timestamp'] == datetime.fromisoformat("2020-01-31T13:34:15")
+        assert exchange['request']['timestamp'] == datetime.fromisoformat(
+            "2018-11-13T20:20:39+02:00")
+        assert exchange['response']['timestamp'] == datetime.fromisoformat(
+            "2020-01-31T13:34:15")
 
 
 def test_invalid_timestamp_in_json():
     with open(SAMPLE_JSON, "r", encoding="utf-8") as f:
         json_string = f.read().replace("2018-11-13T20:20:39+02:00", "INVALID_STRING")
         try:
-            exchange = HttpExchangeReader.from_json(json_string)
+            HttpExchangeReader.from_json(json_string)
             raise AssertionError("No exception raised from invalid timestamp")
         except ValueError as e:
             assert str(e).startswith("Invalid isoformat string")


### PR DESCRIPTION
- Add more stringent checks for valid urls, compute path from regex instead of split
- [ ]  Should `path` and `pathname` for `https://api.github.com` be `/` or an empty string?