### PR TITLE
Avoid depending on native C code

### DIFF
--- a/http_types/utils.py
+++ b/http_types/utils.py
@@ -77,6 +77,15 @@ def delete_none_entries(d):
     return result
 
 
+def parse_iso860_datetime(input_string: str) -> datetime:
+    try:
+        return isoparse(input_string)
+    except ValueError:
+        # The error message from isoparse() is not informative,
+        # so we provide our own:
+        raise ValueError("Invalid isoformat string: " + input_string)
+
+
 class RequestBuilder:
     def __init__(self):
         raise Exception("Do not instantiate")
@@ -112,13 +121,7 @@ class RequestBuilder:
             obj_copy['bodyAsJson'] = body_as_json
 
         if "timestamp" in obj_copy:
-            string_format = obj_copy['timestamp']
-            try:
-                obj_copy['timestamp'] = isoparse(string_format)
-            except ValueError:
-                # The error message from isoparse() is not informative,
-                # so we provide our own:
-                raise ValueError("Invalid isoformat string: INVALID_STRING")
+            obj_copy['timestamp'] = parse_iso860_datetime(obj_copy['timestamp'])
 
         req = Request(**obj_copy)
         RequestBuilder.validate(req)
@@ -206,8 +209,7 @@ class ResponseBuilder:
             obj_copy['bodyAsJson'] = body_as_json
 
         if "timestamp" in obj_copy:
-            obj_copy['timestamp'] = isoparse(
-                obj_copy['timestamp'])
+            obj_copy['timestamp'] = parse_iso860_datetime(obj_copy['timestamp'])
 
         res = Response(**obj_copy)
         ResponseBuilder.validate(res)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
 REQUIRED = [
-    'backports-datetime-fromisoformat',
+    'python-dateutil',
     'typing-extensions',
     'typeguard>=2.7.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ DEV = [
     'pyhamcrest'
 ]
 
-VERSION = '0.0.5'
+VERSION = '0.0.6'
 
 # Optional packages
 EXTRAS = {'dev': DEV}

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,10 +1,10 @@
 from http_types.utils import RequestBuilder
-from datetime import datetime
 from io import StringIO
 from os import path
 import os
 import json
 from http_types import HttpExchange, HttpExchangeBuilder, HttpExchangeReader, HttpExchangeWriter
+from dateutil.parser import isoparse
 from typeguard import check_type  # type: ignore
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -70,9 +70,9 @@ def test_from_url_with_root_path():
 def test_from_json():
     with open(SAMPLE_JSON, "r", encoding="utf-8") as f:
         exchange = HttpExchangeReader.from_json(f.read())
-        assert exchange['request']['timestamp'] == datetime.fromisoformat(
+        assert exchange['request']['timestamp'] == isoparse(
             "2018-11-13T20:20:39+02:00")
-        assert exchange['response']['timestamp'] == datetime.fromisoformat(
+        assert exchange['response']['timestamp'] == isoparse(
             "2020-01-31T13:34:15")
 
 
@@ -83,7 +83,7 @@ def test_invalid_timestamp_in_json():
             HttpExchangeReader.from_json(json_string)
             raise AssertionError("No exception raised from invalid timestamp")
         except ValueError as e:
-            assert str(e).startswith("Invalid isoformat string")
+            assert str(e) == "Invalid isoformat string: INVALID_STRING"
 
 
 def test_from_jsonl():


### PR DESCRIPTION
The backports.datetime_fromisoformat dependency compiles C code, which makes it a lot harder for users.
    
Switch instead to dateutil.parser, which also has the advantage that it supports arbitrary ISO 8601 strings, while [datetime.fromisoformat says](https://docs.python.org/dev/library/datetime.html#datetime.datetime.fromisoformat):
    
> Caution This does not support parsing arbitrary ISO 8601 strings - it is only intended as the inverse operation of datetime.isoformat(). A more full-featured ISO 8601 parser, dateutil.parser.isoparse is available in the third-party package dateutil."