### PR TITLE
Add black and flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs: # A basic unit of work in a run
       - run:
           command: |
             sudo pip install pipenv
-            pipenv install -e .[dev]
+            # See https://github.com/psf/black/issues/517 for why black version is specified:
+            pipenv install -e .[dev] black==19.10b0
             pipenv update
       - save_cache: # cache Python dependencies using checksum of Pipfile as the cache-key
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -27,17 +28,15 @@ jobs: # A basic unit of work in a run
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"
       - run:
-          command: |
-            export VENV_HOME_DIR=$(pipenv --venv)
-            source $VENV_HOME_DIR/bin/activate
-            pytest -s
-      - run:
-          name: Install pyright and run typecheck
+          name: Install pyright
           command: |
             set +e
             echo 'export PATH=$(yarn global bin):$PATH' >> $BASH_ENV
             source $BASH_ENV
             yarn global add pyright
+      - run:
+          command: |
             export VENV_HOME_DIR=$(pipenv --venv)
             source $VENV_HOME_DIR/bin/activate
-            pyright --lib
+            black --check .
+            python setup.py test

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+ignore = E203, E266, E501, W503
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/README.md#line-length for more details
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+# We need to configure the mypy.ini because the flake8-mypy's default
+# options don't properly override it, so if we don't specify it we get
+# half of the config from mypy.ini and half from flake8-mypy.
+mypy_config = mypy.ini

--- a/README.md
+++ b/README.md
@@ -77,22 +77,16 @@ ResponseBuilder.validate(res)  # Validate `Response` object
 
 1. Create a new virtual environment.
 1. Install dependencies: `pip install --upgrade -e '.[dev]'`
+1. Install [pyright](https://github.com/microsoft/pyright).
 
 ### Running tests
 
-Run `pytest tests/` or `python setup.py test`.
+Run `python setup.py test`, which will:
 
-Configuration for `pytest` is found in [pytest.ini](./pytest.ini) file.
-
-### Running type-checking
-
-Install [pyright](https://github.com/microsoft/pyright) and run `pyright --lib` or `python setup.py typecheck`.
-
-Configuration for `pyright` is found in [pyrightconfig.json](./pyrightconfig.json) file.
-
-### Automated tests
-
-See [.circleci/config.yml](./.circleci/config.yml).
+- Enforce code formatting using [black](https://black.readthedocs.io/en/stable/).
+- Test with `pytest`, configured in [pytest.ini](./pytest.ini).
+- Type check with `pyright`, configured in [pyrightconfig.json](./pyrightconfig.json).
+- Enforce style guide with [flake8](https://flake8.pycqa.org/en/latest/), configured in [.flake8](./.flake8).
 
 ### Publishing package
 

--- a/http_types/__init__.py
+++ b/http_types/__init__.py
@@ -1,7 +1,7 @@
 from . import types
-from .types import *
+from .types import *  # noqa: F401,F403
 from . import utils
-from .utils import *
+from .utils import *  # noqa: F401,F403
 
 __all__ = []
 __all__ += types.__all__

--- a/http_types/types.py
+++ b/http_types/types.py
@@ -15,20 +15,14 @@ Query = Mapping[str, Union[str, Sequence[str]]]
 """
 HTTP request protocol.
 """
-Protocol = Literal['http', 'https']
+Protocol = Literal["http", "https"]
 
 """
 HTTP method.
 """
-HttpMethod = Literal['get',
-                     'put',
-                     'post',
-                     'patch',
-                     'delete',
-                     'options',
-                     'trace',
-                     'head',
-                     'connect']
+HttpMethod = Literal[
+    "get", "put", "post", "patch", "delete", "options", "trace", "head", "connect"
+]
 
 
 class _Request(TypedDict, total=False):
@@ -132,9 +126,17 @@ class HttpExchange(TypedDict, total=True):
     """
     HTTP request-response pair.
     """
+
     request: Request
     response: Response
 
 
-__all__ = ["Request", "Response", "HttpExchange",
-           "Headers", "Query", "Protocol", "HttpMethod"]
+__all__ = [
+    "Request",
+    "Response",
+    "HttpExchange",
+    "Headers",
+    "Query",
+    "Protocol",
+    "HttpMethod",
+]

--- a/setup.py
+++ b/setup.py
@@ -4,44 +4,43 @@ import os
 import sys
 
 # Package meta-data.
-NAME = 'http-types'
-DESCRIPTION = 'Types for HTTP requests and responses'
-URL = 'http://github.com/Meeshkan/py-http-types'
-EMAIL = 'dev@meeshkan.com'
-AUTHOR = 'Meeshkan Dev Team'
-REQUIRES_PYTHON = '>=3.6.0'
+NAME = "http-types"
+DESCRIPTION = "Types for HTTP requests and responses"
+URL = "http://github.com/Meeshkan/py-http-types"
+EMAIL = "dev@meeshkan.com"
+AUTHOR = "Meeshkan Dev Team"
+REQUIRES_PYTHON = ">=3.6.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = '\n' + f.read()
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = "\n" + f.read()
 
-REQUIRED = [
-    'python-dateutil>=2.8.1',
-    'typing-extensions',
-    'typeguard>=2.7.0'
-]
+REQUIRED = ["python-dateutil>=2.8.1", "typing-extensions", "typeguard>=2.7.0"]
 
 DEV = [
-    'pytest',
-    'pylint',
-    'autopep8',
-    'setuptools',
-    'twine',
-    'wheel',
-    'pytest-watch',
-    'pytest-testmon',
-    'pyhamcrest'
+    "autopep8",
+    "black",
+    "flake8",
+    "pyhamcrest",
+    "pylint",
+    "pytest",
+    "pytest-testmon",
+    "pytest-watch",
+    "setuptools",
+    "twine",
+    "wheel",
 ]
 
-VERSION = '0.0.7'
+VERSION = "0.0.7"
 
 # Optional packages
-EXTRAS = {'dev': DEV}
+EXTRAS = {"dev": DEV}
 
 
 class SetupCommand(Command):
     """Base class for setup.py commands with no arguments"""
+
     user_options = []
 
     def initialize_options(self):
@@ -53,7 +52,7 @@ class SetupCommand(Command):
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print("\033[1m{0}\033[0m".format(s))
 
     def rmdir_if_exists(self, directory):
         self.status("Deleting {}".format(directory))
@@ -62,7 +61,10 @@ class SetupCommand(Command):
 
 def build():
     return os.system(
-        "{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
+        "{executable} setup.py sdist bdist_wheel --universal".format(
+            executable=sys.executable
+        )
+    )
 
 
 def type_check():
@@ -71,11 +73,12 @@ def type_check():
 
 class BuildDistCommand(SetupCommand):
     """Support setup.py upload."""
+
     description = "Build the package."
 
     def run(self):
         self.status("Removing previous builds...")
-        self.rmdir_if_exists(os.path.join(here, 'dist'))
+        self.rmdir_if_exists(os.path.join(here, "dist"))
 
         self.status("Building Source and Wheel (universal) distribution...")
         exit_code = build()
@@ -86,36 +89,52 @@ class BuildDistCommand(SetupCommand):
 
 class TypeCheckCommand(SetupCommand):
     """Run type-checking."""
+
     description = "Run type-checking."
 
     def run(self):
         exit_code = type_check()
-        self.status(
-            "Typecheck exited with code: {code}".format(code=exit_code))
+        self.status("Typecheck exited with code: {code}".format(code=exit_code))
         if exit_code != 0:
             raise errors.DistutilsError("Type-checking failed.")
 
 
 class TestCommand(SetupCommand):
     """Support setup.py test."""
+
     description = "Run local test if they exist"
 
     def run(self):
+        self.status("Formatting code with black...")
+        exit_code = os.system("black .")
+        if exit_code != 0:
+            raise errors.DistutilsError("Formatting with black failed.")
+
+        self.status("Running pytest...")
         exit_code = os.system("pytest")
-        self.status(
-            "Tests exited with code: {code}".format(code=exit_code))
         if exit_code != 0:
             raise errors.DistutilsError("Tests failed.")
+
+        self.status("Running type-checking...")
+        exit_code = type_check()
+        if exit_code != 0:
+            raise errors.DistutilsError("Type-checking failed.")
+
+        self.status("Running flake8...")
+        exit_code = os.system("flake8 --exclude .git,.venv,__pycache__,build,dist")
+        if exit_code != 0:
+            raise errors.DistutilsError(" failed.")
 
 
 class UploadCommand(SetupCommand):
     """Support setup.py upload."""
+
     description = "Build and publish the package."
 
     def run(self):
 
         self.status("Removing previous builds...")
-        self.rmdir_if_exists(os.path.join(here, 'dist'))
+        self.rmdir_if_exists(os.path.join(here, "dist"))
 
         self.status("Building Source and Wheel (universal) distribution...")
         exit_code = build()
@@ -131,28 +150,31 @@ class UploadCommand(SetupCommand):
         sys.exit()
 
 
-setup(name=NAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url=URL,
-      author=AUTHOR,
-      author_email=EMAIL,
-      python_requires=REQUIRES_PYTHON,
-      license='MIT',
-      packages=find_packages(exclude=["tests"]),
-      include_package_data=True,
-      install_requires=REQUIRED,
-      extras_require=EXTRAS,
-      classifiers=[
-          'Programming Language :: Python :: 3',
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: OS Independent',
-      ],
-      zip_safe=False,
-      cmdclass={'dist': BuildDistCommand,
-                'test': TestCommand,
-                'typecheck': TypeCheckCommand,
-                'upload': UploadCommand}
-      )
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url=URL,
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    license="MIT",
+    packages=find_packages(exclude=["tests"]),
+    include_package_data=True,
+    install_requires=REQUIRED,
+    extras_require=EXTRAS,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    zip_safe=False,
+    cmdclass={
+        "dist": BuildDistCommand,
+        "test": TestCommand,
+        "typecheck": TypeCheckCommand,
+        "upload": UploadCommand,
+    },
+)

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -2,18 +2,22 @@ from http_types import Request, Response
 from typeguard import check_type  # type:ignore
 from datetime import datetime
 
-req = Request(method="get",
-              host="api.github.com",
-              path="/user/repos?id=1",
-              pathname="/user/repos",
-              protocol="https",
-              query={"id": ["1"]},
-              body="",
-              bodyAsJson="",
-              headers={},
-              timestamp=datetime.now())
+req = Request(
+    method="get",
+    host="api.github.com",
+    path="/user/repos?id=1",
+    pathname="/user/repos",
+    protocol="https",
+    query={"id": ["1"]},
+    body="",
+    bodyAsJson="",
+    headers={},
+    timestamp=datetime.now(),
+)
 
-res = Response(statusCode=200, body="OK", bodyAsJson="OK", headers={}, timestamp=datetime.now())
+res = Response(
+    statusCode=200, body="OK", bodyAsJson="OK", headers={}, timestamp=datetime.now()
+)
 
 
 def test_request_typechecks():

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -3,7 +3,12 @@ from io import StringIO
 from os import path
 import os
 import json
-from http_types import HttpExchange, HttpExchangeBuilder, HttpExchangeReader, HttpExchangeWriter
+from http_types import (
+    HttpExchange,
+    HttpExchangeBuilder,
+    HttpExchangeReader,
+    HttpExchangeWriter,
+)
 from dateutil.parser import isoparse
 from typeguard import check_type  # type: ignore
 
@@ -28,54 +33,52 @@ def test_typeguard():
 
 def test_request_from_dict():
     dict_req = {
-        'host': 'api.github.com',
-        'protocol': 'https',
-        'method': 'get',
-        'pathname': '/v1/users',
-        'query': {'a': 'b', 'q': ['1', '2']}
+        "host": "api.github.com",
+        "protocol": "https",
+        "method": "get",
+        "pathname": "/v1/users",
+        "query": {"a": "b", "q": ["1", "2"]},
     }
     req = RequestBuilder.from_dict(dict_req)
-    assert req['method'] == "get"
-    assert req['host'] == "api.github.com"
-    assert req['protocol'] == "https"
-    assert req['body'] == ''
-    assert req['headers'] == {}
-    assert req['pathname'] == '/v1/users'
-    assert req['path'] == '/v1/users?a=b&q=1&q=2'
+    assert req["method"] == "get"
+    assert req["host"] == "api.github.com"
+    assert req["protocol"] == "https"
+    assert req["body"] == ""
+    assert req["headers"] == {}
+    assert req["pathname"] == "/v1/users"
+    assert req["path"] == "/v1/users?a=b&q=1&q=2"
 
 
 def test_from_url():
     test_url = "https://api.github.com/v1/repos?id=1&q=v1&q=v2"
     req = RequestBuilder.from_url(test_url)
-    assert req['method'] == "get"
-    assert req['host'] == "api.github.com"
-    assert req['protocol'] == "https"
-    assert req['path'] == "/v1/repos?id=1&q=v1&q=v2"
-    assert req['pathname'] == "/v1/repos"
-    assert req['query'] == {'id': "1", 'q': ["v1", "v2"]}
+    assert req["method"] == "get"
+    assert req["host"] == "api.github.com"
+    assert req["protocol"] == "https"
+    assert req["path"] == "/v1/repos?id=1&q=v1&q=v2"
+    assert req["pathname"] == "/v1/repos"
+    assert req["query"] == {"id": "1", "q": ["v1", "v2"]}
 
 
 def test_from_url_without_path():
     test_url = "https://api.github.com"
     req = RequestBuilder.from_url(test_url)
-    assert req['path'] == "/"
-    assert req['pathname'] == "/"
+    assert req["path"] == "/"
+    assert req["pathname"] == "/"
 
 
 def test_from_url_with_root_path():
     test_url = "https://api.github.com/"
     req = RequestBuilder.from_url(test_url)
-    assert req['path'] == "/"
-    assert req['pathname'] == "/"
+    assert req["path"] == "/"
+    assert req["pathname"] == "/"
 
 
 def test_from_json():
     with open(SAMPLE_JSON, "r", encoding="utf-8") as f:
         exchange = HttpExchangeReader.from_json(f.read())
-        assert exchange['request']['timestamp'] == isoparse(
-            "2018-11-13T20:20:39+02:00")
-        assert exchange['response']['timestamp'] == isoparse(
-            "2020-01-31T13:34:15")
+        assert exchange["request"]["timestamp"] == isoparse("2018-11-13T20:20:39+02:00")
+        assert exchange["response"]["timestamp"] == isoparse("2020-01-31T13:34:15")
 
 
 def test_invalid_timestamp_in_json():
@@ -96,17 +99,17 @@ def test_from_jsonl():
 
 def validate_sample_exchanges(exchanges):
     assert len(exchanges) == 3
-    assert exchanges[0]['request']['protocol'] == "http"
-    assert exchanges[1]['request']['protocol'] == "https"
+    assert exchanges[0]["request"]["protocol"] == "http"
+    assert exchanges[1]["request"]["protocol"] == "https"
 
     for exchange in exchanges[0:2]:
-        assert exchange['request']['path'] == '/user/repos?q=v'
-        assert exchange['request']['pathname'] == '/user/repos'
-        assert exchange['request']['query'] == {'q': "v"}
+        assert exchange["request"]["path"] == "/user/repos?q=v"
+        assert exchange["request"]["pathname"] == "/user/repos"
+        assert exchange["request"]["query"] == {"q": "v"}
 
-    assert exchanges[2]['request']['path'] == '/user/repos'
-    assert exchanges[2]['request']['pathname'] == '/user/repos'
-    assert exchanges[2]['request']['query'] == {}
+    assert exchanges[2]["request"]["path"] == "/user/repos"
+    assert exchanges[2]["request"]["pathname"] == "/user/repos"
+    assert exchanges[2]["request"]["query"] == {}
 
 
 def test_writing_json():


### PR DESCRIPTION
This PR adds:

- Code formatting using [black](https://black.readthedocs.io/en/stable/). This tool seems to be gaining a lot of momentum, has been moved into the Python Software Foundation, and is a nice way to minimise diffs and not having to care about code formatting (just make it auto-format using black on save).
- Style guide checks using [flake8](https://flake8.pycqa.org/en/latest/).
- Makes `python setup.py test` run everything (black, flake8, pytest, pyright) so you don't have to think about the individual steps (and it simplifies the README somewhat).