### PR TITLE
Default optional fields on dataclasses to None

### DIFF
--- a/http_types/types.py
+++ b/http_types/types.py
@@ -47,21 +47,6 @@ class Request:
     """
 
     """
-    HTTP request body as JSON. Could be dictionary, list, or string.
-    """
-    bodyAsJson: Optional[Any]
-
-    """
-    Timestamp when the request was initiated.
-    """
-    timestamp: Optional[datetime]
-
-    """
-    Request body. None if no body should exit (ie GET, DELETE). Empty string if empty.
-    """
-    body: Optional[str]
-
-    """
     Request method.
     """
     method: HttpMethod
@@ -98,22 +83,27 @@ class Request:
     """
     protocol: Protocol
 
+    """
+    HTTP request body as JSON. Could be dictionary, list, or string.
+    """
+    bodyAsJson: Optional[Any] = None
+
+    """
+    Timestamp when the request was initiated.
+    """
+    timestamp: Optional[datetime] = None
+
+    """
+    Request body. None if no body should exit (ie GET, DELETE). Empty string if empty.
+    """
+    body: Optional[str] = None
+
 
 @dataclass
 class Response:
     """
     HTTP response.
     """
-
-    """
-    Response body as JSON. Could be dictionary, list, or string.
-    """
-    bodyAsJson: Optional[Any]
-
-    """
-    Timestamp when the response was sent.
-    """
-    timestamp: Optional[datetime]
 
     """
     Response body.
@@ -125,6 +115,16 @@ class Response:
 
     """ Response headers. """
     headers: Headers
+
+    """
+    Timestamp when the response was sent.
+    """
+    timestamp: Optional[datetime] = None
+
+    """
+    Response body as JSON. Could be dictionary, list, or string.
+    """
+    bodyAsJson: Optional[Any] = None
 
 
 @dataclass

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -27,3 +27,20 @@ def test_request_typechecks():
 
 def test_response_typechecks():
     check_type("res", res, Response)
+
+
+def request_and_response_can_be_instantiated_without_timestamp():
+    request = Request(
+        method=HttpMethod.GET,
+        host="api.github.com",
+        path="/user/repos?id=1",
+        pathname="/user/repos",
+        protocol=Protocol.HTTPS,
+        query={"id": ["1"]},
+        body="",
+        bodyAsJson="",
+        headers={},
+    )
+    assert request.timestamp is None
+    response = Response(statusCode=200, body="OK", bodyAsJson="OK", headers={})
+    assert response.timestamp is None


### PR DESCRIPTION
What about this change, allowing optional fields to be left out when constructing instances?

```python
# Currently:
response = Response(statusCode=200, body="OK", bodyAsJson="OK", headers={}, timestamp=None)
# With this PR:
response = Response(statusCode=200, body="OK", bodyAsJson="OK", headers={})
```

This is something that Nakul reacted on, being forced to specify `timestamp` even though it's an optional property.