### PR TITLE
Replace setuptools.errors with distutils.errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import find_packages, setup, Command, errors
+from distutils import errors
+from setuptools import find_packages, setup, Command
 from shutil import rmtree
 import os
 import sys
@@ -38,7 +39,7 @@ DEV = [
     "wheel",
 ]
 
-VERSION = "0.0.15"
+VERSION = "0.0.16"
 
 # Optional packages
 EXTRAS = {"dev": DEV}


### PR DESCRIPTION
Doing this makes us compatible with the

    python3 -m venv .venv

setup, without any extra step required to use virtualenv or upgrade setuptools.