### PR TITLE
Populate request.body from bodyAsJson if given

### DIFF
--- a/http_types/utils.py
+++ b/http_types/utils.py
@@ -183,13 +183,15 @@ class RequestBuilder:
             path = obj_copy["path"]
             obj_copy["pathname"] = parse_pathname(path)
 
+        bodyAsJson = obj_copy.get("bodyAsJson", None)
+
         if obj_copy.get("body", None) is None:
-            obj_copy["body"] = ""
+            obj_copy["body"] = json.dumps(bodyAsJson) if bodyAsJson else ""
 
         if obj_copy.get("headers", None) is None:
             obj_copy["headers"] = {}
 
-        if obj_copy.get("bodyAsJson", None) is None:
+        if bodyAsJson is None:
             body_as_json = parse_body(obj_copy["body"])
             obj_copy["bodyAsJson"] = body_as_json
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ DEV = [
     "wheel",
 ]
 
-VERSION = "0.0.17"
+VERSION = "0.0.18"
 
 # Optional packages
 EXTRAS = {"dev": DEV}

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -62,6 +62,18 @@ def test_request_from_dict():
     assert req.path == "/v1/users?a=b&q=1&q=2"
 
 
+def test_request_with_bodyAsJson():
+    dict_req = {
+        "host": "example.com",
+        "protocol": "http",
+        "method": "post",
+        "path": "/a/path",
+        "bodyAsJson": {"key": "value"},
+    }
+    req = RequestBuilder.from_dict(dict_req)
+    assert req.body == '{"key": "value"}'
+
+
 def test_validate_protocol():
     assert RequestBuilder.validate_protocol("http") == Protocol.HTTP
     assert RequestBuilder.validate_protocol("https") == Protocol.HTTPS


### PR DESCRIPTION
If RequestBuilder.from_dict() is given a bodyAsJson field and no body field, it makes sense to populate the requesty.body field with the serialized value of bodyAsJson.

Fixes test_runner logging of graphql requests which makes this assumption.

Also bump the version to prepare for a release once this gets merged.